### PR TITLE
topページ新着アイテム内コンテンツのマークアップ

### DIFF
--- a/app/assets/stylesheets/top_contents.scss
+++ b/app/assets/stylesheets/top_contents.scss
@@ -69,12 +69,51 @@
       display: flex;
       justify-content: space-between;
       flex-wrap: wrap;
+      a{
+        text-decoration: none;
+        color: #fff;
+      }
       &__product {
         background-color: white;
         height: 252px;
         width: 188px;
         box-shadow: 1px 3px 3px rgba(0, 0, 0, .2);
         margin-top: 16px;
+        &__image {
+          height: 188px;
+          width: 188px;
+          position: relative;
+          .price {
+            font-size: 17px;
+            display: inline-flex;
+            align-items: center;
+            background: rgba(0, 0, 0, .4);
+            border-radius: 0 14px 14px 0;
+            padding: 0 12px;
+            letter-spacing: .2em;
+            position: absolute;
+            bottom: 8px;
+            left: 0;
+            z-index: 2;
+            height: 28px;
+          }
+        }
+        &__caption {
+          height: 64px;
+          padding: 0 12px;
+          font-size: 14px;
+          color: #222;
+          white-space: normal;
+          word-break: break-all;
+          line-height: 1.4em;
+          display: flex;
+          align-items: center;
+          &__text {
+            overflow: hidden;
+            height: 2.8em;
+            display: inline-block;
+          }
+        }
       }
     }
   }

--- a/app/views/items/_list.html.haml
+++ b/app/views/items/_list.html.haml
@@ -8,5 +8,11 @@
           %i.fa.fa-chevron-right
     .m-items__container__products
       - (1..15).each do
-        .m-items__container__products__product
-
+        = link_to "#" do
+          .m-items__container__products__product
+            .m-items__container__products__product__image
+              = image_tag 'https://static.mercdn.net/thumb/photos/m84431990341_1.jpg?1570765723', height: '188px', width: '188px'
+              %span.price ¥38
+            .m-items__container__products__product__caption
+              .m-items__container__products__product__caption__text
+                鯖缶


### PR DESCRIPTION
# What
topページのアイテム一覧に表示されるアイテムの画像、価格、商品名のマークアップを行い、仮置きする

# Why
ユーザビリティ向上のため